### PR TITLE
Add graph utilities and unit tests

### DIFF
--- a/__tests__/graphUtils.test.js
+++ b/__tests__/graphUtils.test.js
@@ -1,0 +1,46 @@
+const { addNode, addEdge, deleteNode, deleteEdge, saveGraph, loadGraph } = require('../lib/graphUtils');
+
+describe('graphUtils', () => {
+  let graph;
+  beforeEach(() => {
+    graph = { nodes: [], edges: [] };
+  });
+
+  test('addNode adds a node with default label', () => {
+    addNode(graph, 'n1');
+    expect(graph.nodes).toEqual([{ id: 'n1', label: 'n1' }]);
+  });
+
+  test('addEdge adds an edge with defaults', () => {
+    addEdge(graph, 'n1', 'n2');
+    expect(graph.edges).toEqual([{ source: 'n1', target: 'n2', type: '', weight: 1 }]);
+  });
+
+  test('deleteNode removes node and connected edges', () => {
+    addNode(graph, 'n1');
+    addNode(graph, 'n2');
+    addEdge(graph, 'n1', 'n2');
+    deleteNode(graph, 'n1');
+    expect(graph.nodes).toEqual([{ id: 'n2', label: 'n2' }]);
+    expect(graph.edges).toEqual([]);
+  });
+
+  test('deleteEdge removes specific edge', () => {
+    addEdge(graph, 'n1', 'n2');
+    addEdge(graph, 'n1', 'n3');
+    deleteEdge(graph, 'n1', 'n2');
+    expect(graph.edges).toEqual([{ source: 'n1', target: 'n3', type: '', weight: 1 }]);
+  });
+
+  test('saveGraph serializes graph to JSON', () => {
+    addNode(graph, 'n1');
+    const json = saveGraph(graph);
+    expect(JSON.parse(json)).toEqual({ nodes: [{ id: 'n1', label: 'n1' }], edges: [] });
+  });
+
+  test('loadGraph parses JSON to graph object', () => {
+    const jsonStr = '{"nodes":[{"id":"a"}],"edges":[]}';
+    const data = loadGraph(jsonStr);
+    expect(data).toEqual({ nodes: [{ id: 'a' }], edges: [] });
+  });
+});

--- a/lib/graphUtils.js
+++ b/lib/graphUtils.js
@@ -1,0 +1,47 @@
+function addNode(graph, id, label) {
+    if (!id) throw new Error('id required');
+    if (!label) label = id;
+    graph.nodes.push({ id, label });
+    return graph;
+}
+
+function addEdge(graph, source, target, type = '', weight = 1) {
+    if (!source || !target) throw new Error('source and target required');
+    if (isNaN(weight)) weight = 1;
+    graph.edges.push({ source, target, type, weight });
+    return graph;
+}
+
+function deleteNode(graph, nodeId) {
+    if (!nodeId) throw new Error('nodeId required');
+    graph.nodes = graph.nodes.filter(n => n.id !== nodeId);
+    graph.edges = graph.edges.filter(e => e.source !== nodeId && e.target !== nodeId);
+    return graph;
+}
+
+function deleteEdge(graph, source, target) {
+    if (!source || !target) throw new Error('source and target required');
+    graph.edges = graph.edges.filter(e => e.source !== source || e.target !== target);
+    return graph;
+}
+
+function saveGraph(graph) {
+    return JSON.stringify(graph, null, 2);
+}
+
+function loadGraph(jsonStr) {
+    const data = JSON.parse(jsonStr);
+    return {
+        nodes: data.nodes || [],
+        edges: data.edges || []
+    };
+}
+
+module.exports = {
+    addNode,
+    addEdge,
+    deleteNode,
+    deleteEdge,
+    saveGraph,
+    loadGraph
+};

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "scripts": {
     "start": "electron .",
     "pack": "electron-packager . MyApp --platform=win32 --arch=x64 --out=dist/ --overwrite",
-    "build": "electron-builder"
+    "build": "electron-builder",
+    "test": "jest"
   },
   "devDependencies": {
     "electron": "^25.0.0",
     "electron-builder": "^25.1.8",
-    "electron-packager": "^17.1.2"
+    "electron-packager": "^17.1.2",
+    "jest": "^29.7.0"
   },
   "build": {
     "appId": "com.example.myapp",


### PR DESCRIPTION
## Summary
- create `graphUtils` module with functions for node/edge operations
- add Jest unit tests covering add/delete operations and save/load
- configure npm test script and add Jest to dev deps

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f58910e2c8323a40220d4ffccd6e8