### PR TITLE
Add README instructions for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,8 @@ Launching the app with `npm start` opens the Electron window with tabs for build
 1. Install dependencies with `npm install`.
 2. Start the application using `npm start`.
 
+## Testing
+Run `npm test` to execute the Jest test suite found in the `__tests__` directory.
+
 ## Packaging
 Additional scripts for building and packaging the app are defined in `package.json` (`npm run build`, `npm run pack`).


### PR DESCRIPTION
## Summary
- document `npm test` usage in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f68d9a93c83239482adb66a7b1ebe