### PR TITLE
Update README with Node/Electron versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,9 @@ Launching the app with `npm start` opens the Electron window with tabs for build
 1. Install dependencies with `npm install`.
 2. Start the application using `npm start`.
 
+## Development Environment
+This project was developed using **Node.js v20.19.2** together with **Electron v25.0.0**.
+Using a version manager such as [`nvm`](https://github.com/nvm-sh/nvm) makes it easy to match these versions.
+
 ## Packaging
 Additional scripts for building and packaging the app are defined in `package.json` (`npm run build`, `npm run pack`).


### PR DESCRIPTION
## Summary
- document Node.js and Electron versions used during development
- recommend using `nvm` for Node version management

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f68e18e748323bf899fac35941dba