### PR TITLE
Improve graph resize behavior

### DIFF
--- a/graph_editor_new.html
+++ b/graph_editor_new.html
@@ -66,8 +66,8 @@
     
     <div id="graph-container">
         <div id="network" class="vis-network"></div>
+        <div class="resizer"></div> <!-- Resizer element for resizing the graph container -->
     </div>
-    <div class="resizer"></div> <!-- Resizer element for resizing the graph container -->
     
     
     <script>
@@ -270,7 +270,8 @@
                     graphContainer.style.width = newWidth + 'px';
                     graphContainer.style.height = newHeight + 'px';
                     if (network) {
-                        network.redraw(); // Redraw the network to adjust
+                        network.setSize(newWidth + 'px', newHeight + 'px');
+                        network.fit(); // adjust view to new container
                     }
                 }
             }

--- a/index.html
+++ b/index.html
@@ -37,11 +37,11 @@
     <div class="tab-content" id="myTabContent">
         <!-- Content for the Graph Editor tab -->
         <div class="tab-pane fade show active" id="editor" role="tabpanel">
-            <iframe src="graph_editor_new.html" style="width: 100%; height: calc(100vh - 150px); border: none;"></iframe>
+            <iframe src="graph_editor_new.html" style="width: 100%; height: 100vh; border: none;"></iframe>
         </div>
         <!-- Content for the Graph Analysis Tool tab -->
         <div class="tab-pane fade" id="analysis" role="tabpanel">
-            <iframe src="analysis_tool.html" style="width: 100%; height: calc(100vh - 150px); border: none;"></iframe>
+            <iframe src="analysis_tool.html" style="width: 100%; height: 100vh; border: none;"></iframe>
         </div>
     </div>
     


### PR DESCRIPTION
## Summary
- move resizer inside `#graph-container`
- call `network.setSize` and `network.fit` when resizing
- adjust iframe height to fill viewport

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840436b83dc8323a880c23767dc5f2c