### PR TITLE
Improve graph analysis robustness

### DIFF
--- a/py/analysis_test.py
+++ b/py/analysis_test.py
@@ -16,6 +16,7 @@ def test_simple_graph():
     assert result['influence_scores'] == {'A': 0, 'B': 1, 'C': 2}
     assert result['positive_paths'] == [['A', 'B', 'C']]
     assert result['negative_paths'] == []
+    assert result['error'] == ''
 
 
 def test_all_negative_edges():
@@ -32,6 +33,7 @@ def test_all_negative_edges():
     assert result['influence_scores'] == {'A': 0, 'B': -1, 'C': -1}
     assert result['positive_paths'] == []
     assert result['negative_paths'] == []
+    assert result['error'] == ''
 
 
 def test_disconnected_graph():
@@ -47,6 +49,7 @@ def test_disconnected_graph():
     assert result['influence_scores'] == {'A': 0, 'B': 1, 'C': 0}
     assert result['positive_paths'] == []
     assert result['negative_paths'] == []
+    assert result['error'] == ''
 
 
 def test_cyclic_graph():
@@ -64,6 +67,7 @@ def test_cyclic_graph():
     # Should handle cycle without infinite loops
     assert result['positive_paths'] == [['A', 'B', 'C']]
     assert result['negative_paths'] == []
+    assert result['error'] == ''
 
 
 def test_zero_weights():
@@ -80,3 +84,15 @@ def test_zero_weights():
     assert result['influence_scores'] == {'A': 0, 'B': 0, 'C': 0}
     assert result['positive_paths'] == []
     assert result['negative_paths'] == []
+    assert result['error'] == ''
+
+
+def test_malformed_graph_returns_error():
+    nodes = [{'id': 'A', 'label': 'A'}, {'id': 'B', 'label': 'B'}]
+    # Edge references non-existent target 'C'
+    edges = [{'source': 'A', 'target': 'C', 'type': '+', 'weight': 1}]
+    result = analyze_graph(nodes, edges)
+    assert result['influence_scores'] == {}
+    assert result['positive_paths'] == []
+    assert result['negative_paths'] == []
+    assert result['error'] != ''

--- a/py/graph_analysis.py
+++ b/py/graph_analysis.py
@@ -16,53 +16,71 @@ def analyze_graph(nodes, edges):
     dict
         Dictionary with keys 'influence_scores', 'positive_paths', 'negative_paths'.
     """
-    G = nx.DiGraph()
-    for node in nodes:
-        G.add_node(
-            node['id'],
-            label=node.get('label', node['id']),
-            type=node.get('type', ''),
-            group=node.get('group', '')
-        )
+    try:
+        G = nx.DiGraph()
+        for node in nodes:
+            node_id = node.get('id')
+            if node_id is None:
+                raise ValueError("Node missing 'id'")
+            G.add_node(
+                node_id,
+                label=node.get('label', node_id),
+                type=node.get('type', ''),
+                group=node.get('group', '')
+            )
 
-    for edge in edges:
-        weight = edge.get('weight', 1)
-        if edge.get('type') == '-':
-            weight = -weight
-        G.add_edge(edge['source'], edge['target'], weight=weight)
+        node_ids = set(G.nodes())
+        for edge in edges:
+            src = edge.get('source')
+            tgt = edge.get('target')
+            if src is None or tgt is None:
+                raise ValueError("Edge missing 'source' or 'target'")
+            if src not in node_ids or tgt not in node_ids:
+                raise ValueError("Edge references missing node")
+            weight = edge.get('weight', 1)
+            if edge.get('type') == '-':
+                weight = -weight
+            G.add_edge(src, tgt, weight=weight)
 
-    id_to_label = {n['id']: n.get('label', n['id']) for n in nodes}
+        id_to_label = {n['id']: n.get('label', n['id']) for n in nodes if n.get('id') is not None}
 
-    influence_scores = {
-        id_to_label[node]: sum(data['weight'] for _, node, data in G.in_edges(node, data=True))
-        for node in G.nodes
-    }
+        influence_scores = {
+            id_to_label.get(node, node): sum(data['weight'] for _, node, data in G.in_edges(node, data=True))
+            for node in G.nodes
+        }
 
-    positive_paths = []
-    negative_paths = []
-    if len(nodes) >= 2:
-        source = nodes[0]['id']
-        target = nodes[-1]['id']
-        try:
-            if nx.has_path(G, source, target):
-                all_weights = [d['weight'] for _, _, d in G.edges(data=True)]
-                if not all_weights or max(all_weights) <= 0:
-                    # All weights are non-positive; return empty paths
-                    positive_paths = []
-                    negative_paths = []
-                else:
-                    cutoff = len(G.nodes())
-                    for path in nx.all_simple_paths(G, source=source, target=target, cutoff=cutoff):
-                        if all(G[u][v]['weight'] > 0 for u, v in zip(path, path[1:])):
-                            positive_paths.append([id_to_label[n] for n in path])
-                        if all(G[u][v]['weight'] < 0 for u, v in zip(path, path[1:])):
-                            negative_paths.append([id_to_label[n] for n in path])
-        except (nx.NetworkXNoPath, nx.NodeNotFound):
-            positive_paths = []
-            negative_paths = []
+        positive_paths = []
+        negative_paths = []
+        if len(nodes) >= 2:
+            source = nodes[0].get('id')
+            target = nodes[-1].get('id')
+            try:
+                if source is not None and target is not None and nx.has_path(G, source, target):
+                    all_weights = [d['weight'] for _, _, d in G.edges(data=True)]
+                    if all_weights and max(all_weights) > 0:
+                        cutoff = len(G.nodes())
+                        try:
+                            for path in nx.all_simple_paths(G, source=source, target=target, cutoff=cutoff):
+                                if all(G[u][v]['weight'] > 0 for u, v in zip(path, path[1:])):
+                                    positive_paths.append([id_to_label.get(n, n) for n in path])
+                                if all(G[u][v]['weight'] < 0 for u, v in zip(path, path[1:])):
+                                    negative_paths.append([id_to_label.get(n, n) for n in path])
+                        except Exception as e:
+                            raise e
+            except Exception as e:
+                raise e
 
-    return {
-        'influence_scores': influence_scores,
-        'positive_paths': positive_paths,
-        'negative_paths': negative_paths
-    }
+        return {
+            'influence_scores': influence_scores,
+            'positive_paths': positive_paths,
+            'negative_paths': negative_paths,
+            'error': ''
+        }
+
+    except Exception as e:
+        return {
+            'influence_scores': {},
+            'positive_paths': [],
+            'negative_paths': [],
+            'error': str(e)
+        }


### PR DESCRIPTION
## Summary
- make `analyze_graph` resilient to malformed graphs
- extend tests for new error handling and edge cases

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407115191c8323867834a441a5b93b