### PR TITLE
Implement graph validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Using a version manager such as [`nvm`](https://github.com/nvm-sh/nvm) makes it 
 ## Testing
 Run `npm test` to execute the Jest test suite found in the `__tests__` directory.
 
+## Graph Validation
+Graphs loaded through the editor or analysis tool are validated against
+[`graphs/GRAPH_SPEC.md`](graphs/GRAPH_SPEC.md). Structural errors such as missing
+IDs or invalid edges cause an alert and prevent rendering, while non-fatal issues
+like missing weights are shown as warnings.
+
 ## Packaging
 Additional scripts for building and packaging the app are defined in `package.json`:
 - `npm run build`

--- a/__tests__/graphValidator.test.js
+++ b/__tests__/graphValidator.test.js
@@ -1,0 +1,34 @@
+const { validateGraph } = require('../lib/graphValidator');
+
+describe('validateGraph', () => {
+  test('catches missing node id', () => {
+    const graph = { nodes: [{ label: 'A' }], edges: [] };
+    const result = validateGraph(graph);
+    expect(result.errors.some(e => e.includes('missing id'))).toBe(true);
+  });
+
+  test('catches duplicate node ids', () => {
+    const graph = { nodes: [{ id: 'a' }, { id: 'a' }], edges: [] };
+    const result = validateGraph(graph);
+    expect(result.errors).toContain('Duplicate node id "a"');
+  });
+
+  test('catches invalid edge references', () => {
+    const graph = { nodes: [{ id: 'a' }, { id: 'b' }], edges: [{ source: 'a', target: 'c' }] };
+    const result = validateGraph(graph);
+    expect(result.errors.some(e => e.includes('references missing node'))).toBe(true);
+  });
+
+  test('warns about missing weight defaults', () => {
+    const graph = { nodes: [{ id: 'a' }, { id: 'b' }], edges: [{ source: 'a', target: 'b' }] };
+    const result = validateGraph(graph);
+    expect(result.warnings.some(w => w.includes('missing weight'))).toBe(true);
+    expect(graph.edges[0].weight).toBe(1);
+  });
+
+  test('catches insufficient node or edge counts', () => {
+    const graph = { nodes: [{ id: 'a' }], edges: [] };
+    const result = validateGraph(graph);
+    expect(result.errors.some(e => e.includes('at least'))).toBe(true);
+  });
+});

--- a/analysis_tool.html
+++ b/analysis_tool.html
@@ -39,6 +39,9 @@
         const currentGraphData = { nodes: [], edges: [] };
         let network;
 
+        // Load validator for graph structure
+        const { validateGraph } = require('./lib/graphValidator');
+
         // Python code to test Pyodide functionality
         const output = document.getElementById("output");
 
@@ -185,6 +188,16 @@
             const fileContent = await file.text();
             try {
                 const data = JSON.parse(fileContent);
+
+                const result = validateGraph(data);
+                if (result.errors.length > 0) {
+                    alert('Graph validation errors:\n' + result.errors.join('\n'));
+                    console.error('Graph validation failed:', result.errors);
+                    return;
+                }
+                if (result.warnings.length > 0) {
+                    alert('Graph validation warnings:\n' + result.warnings.join('\n'));
+                }
 
                 rawGraphData = data;
                 currentGraphData.nodes = data.nodes || [];

--- a/graph_editor_new.html
+++ b/graph_editor_new.html
@@ -74,6 +74,9 @@
         // Wait for DOM content to be ready via wrapparound function ///
         //document.addEventListener("DOMContentLoaded", function() {
 
+            // Load graph validator from Node environment
+            const { validateGraph } = require('./lib/graphValidator');
+
             // Initialize global data
             const currentGraphData = { nodes: [], edges: [] };
             let network;
@@ -239,6 +242,16 @@
                 const fileContent = await file.text();
                 try {
                     const data = JSON.parse(fileContent);
+
+                    const result = validateGraph(data);
+                    if (result.errors.length > 0) {
+                        alert('Graph validation errors:\n' + result.errors.join('\n'));
+                        console.error('Graph validation failed:', result.errors);
+                        return;
+                    }
+                    if (result.warnings.length > 0) {
+                        alert('Graph validation warnings:\n' + result.warnings.join('\n'));
+                    }
 
                     // Update currentGraphData with loaded data
                     currentGraphData.nodes = data.nodes || [];

--- a/lib/graphValidator.js
+++ b/lib/graphValidator.js
@@ -1,0 +1,69 @@
+function validateGraph(graph) {
+    const errors = [];
+    const warnings = [];
+
+    if (!graph || typeof graph !== 'object') {
+        return { errors: ['Graph data must be an object'], warnings };
+    }
+
+    const nodes = Array.isArray(graph.nodes) ? graph.nodes : [];
+    const edges = Array.isArray(graph.edges) ? graph.edges : [];
+
+    const nodeIds = new Set();
+
+    nodes.forEach((node, index) => {
+        if (!node || typeof node !== 'object') {
+            errors.push(`Node at index ${index} is invalid`);
+            return;
+        }
+        if (!node.id) {
+            errors.push(`Node at index ${index} missing id`);
+            return;
+        }
+        if (nodeIds.has(node.id)) {
+            errors.push(`Duplicate node id "${node.id}"`);
+        } else {
+            nodeIds.add(node.id);
+        }
+    });
+
+    if (nodes.length < 2) {
+        errors.push('Graph must contain at least 2 nodes');
+    }
+    if (edges.length < 1) {
+        errors.push('Graph must contain at least 1 edge');
+    }
+
+    const validNodeIds = new Set(nodes.map(n => n.id));
+
+    edges.forEach((edge, index) => {
+        if (!edge || typeof edge !== 'object') {
+            errors.push(`Edge at index ${index} is invalid`);
+            return;
+        }
+        const { source, target } = edge;
+        if (!source || !target) {
+            errors.push(`Edge at index ${index} missing source or target`);
+        } else {
+            if (!validNodeIds.has(source) || !validNodeIds.has(target)) {
+                errors.push(`Edge from ${source} to ${target} references missing node`);
+            }
+        }
+
+        if (edge.weight === undefined) {
+            warnings.push(`Edge from ${source} to ${target} missing weight; defaulting to 1`);
+            edge.weight = 1;
+        } else if (isNaN(edge.weight)) {
+            errors.push(`Edge from ${source} to ${target} has non-numeric weight`);
+        }
+
+        if (edge.type === undefined) {
+            warnings.push(`Edge from ${source} to ${target} missing type; defaulting to '+'`);
+            edge.type = '+';
+        }
+    });
+
+    return { errors, warnings };
+}
+
+module.exports = { validateGraph };


### PR DESCRIPTION
## Summary
- add `validateGraph` utility with checks for node ids, edge references and counts
- integrate graph validation warnings/errors into editor and analysis pages
- document the validation step in `README.md`
- test `validateGraph` behaviour with Jest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840794199608323b9e35009ef1afda7