### PR TITLE
Add graphUtils edge cases

### DIFF
--- a/__tests__/graphUtils.test.js
+++ b/__tests__/graphUtils.test.js
@@ -16,6 +16,20 @@ describe('graphUtils', () => {
     expect(graph.edges).toEqual([{ source: 'n1', target: 'n2', type: '', weight: 1 }]);
   });
 
+  test('addNode without id throws', () => {
+    expect(() => addNode(graph)).toThrow();
+  });
+
+  test('addEdge defaults weight to 1 when NaN', () => {
+    addEdge(graph, 'n1', 'n2', '', NaN);
+    expect(graph.edges).toEqual([{ source: 'n1', target: 'n2', type: '', weight: 1 }]);
+  });
+
+  test('addEdge requires source and target', () => {
+    expect(() => addEdge(graph, null, 'n2')).toThrow();
+    expect(() => addEdge(graph, 'n1')).toThrow();
+  });
+
   test('deleteNode removes node and connected edges', () => {
     addNode(graph, 'n1');
     addNode(graph, 'n2');
@@ -23,6 +37,13 @@ describe('graphUtils', () => {
     deleteNode(graph, 'n1');
     expect(graph.nodes).toEqual([{ id: 'n2', label: 'n2' }]);
     expect(graph.edges).toEqual([]);
+  });
+
+  test('deleteNode ignores missing id', () => {
+    addNode(graph, 'n1');
+    const snapshot = JSON.parse(JSON.stringify(graph));
+    deleteNode(graph, 'missing');
+    expect(graph).toEqual(snapshot);
   });
 
   test('deleteEdge removes specific edge', () => {
@@ -36,6 +57,22 @@ describe('graphUtils', () => {
     addNode(graph, 'n1');
     const json = saveGraph(graph);
     expect(JSON.parse(json)).toEqual({ nodes: [{ id: 'n1', label: 'n1' }], edges: [] });
+  });
+
+  test('saveGraph includes edges', () => {
+    addNode(graph, 'n1');
+    addNode(graph, 'n2');
+    addEdge(graph, 'n1', 'n2', 'arrow', 2);
+    const json = saveGraph(graph);
+    expect(JSON.parse(json)).toEqual({
+      nodes: [
+        { id: 'n1', label: 'n1' },
+        { id: 'n2', label: 'n2' }
+      ],
+      edges: [
+        { source: 'n1', target: 'n2', type: 'arrow', weight: 2 }
+      ]
+    });
   });
 
   test('loadGraph parses JSON to graph object', () => {


### PR DESCRIPTION
## Summary
- expand Jest tests for graphUtils
  - verify required parameters for addNode/addEdge
  - check weight defaults to 1 when NaN
  - ensure deleteNode handles missing IDs
  - confirm saveGraph includes edges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ee54615988323a8266fe4b5b55186