### PR TITLE
Remove redundant title from toolbar - save space and reduce clutter

### DIFF
--- a/src/unified-interface.html
+++ b/src/unified-interface.html
@@ -483,9 +483,6 @@
 <body>
     <!-- Top Toolbar -->
     <div class="toolbar">
-        <h1>Causal Graph Tool</h1>
-        
-        
         <div class="toolbar-section">
             <span>Nodes: <span id="node-count">0</span></span>
             <span>Edges: <span id="edge-count">0</span></span>


### PR DESCRIPTION
## Summary
Fixes Issue #34 - Redundant Information

## Problem
The app displayed "Causal Graph Tool" in two places:
1. **Windows title bar** (OS-level title)
2. **In-app toolbar header** (`<h1>` element)

This was redundant and wasted valuable toolbar space.

## Solution
- **Remove redundant `<h1>` header** from the toolbar
- **Keep window title** (shows in OS title bar as expected)
- **Free up toolbar space** for more useful information (node/edge counts, etc.)

## Before/After
**Before:**
- Title bar: "Causal Graph Tool" 
- Toolbar: "Causal Graph Tool" + stats + controls ❌ Redundant

**After:**
- Title bar: "Causal Graph Tool"
- Toolbar: stats + controls ✅ Clean and efficient

## Benefits
- **Less visual clutter** - removes duplicate information
- **More space** for useful toolbar content
- **Cleaner design** following modern UI conventions
- **Better space utilization** in the interface

## Technical Change
```html
<\!-- REMOVED -->
<div class="toolbar">
    <h1>Causal Graph Tool</h1>  <\!-- Redundant with window title -->
    <div class="toolbar-section">...</div>
</div>

<\!-- CLEAN -->
<div class="toolbar">
    <div class="toolbar-section">...</div>  <\!-- Direct to useful content -->
</div>
```

## Testing
- ✅ All existing tests pass (43/43)
- ✅ No functional impact - purely visual improvement
- ✅ Toolbar remains fully functional with more space

Fixes #34

🤖 Generated with [Claude Code](https://claude.ai/code)