### PR TITLE
Fix context menu handler conflicts preventing add node functionality

### DIFF
--- a/src/unified-interface.html
+++ b/src/unified-interface.html
@@ -791,44 +791,13 @@
                 console.log('Network stabilized, context menus are ready');
             });
             
+            // Disable default browser context menu
             container.addEventListener('contextmenu', (e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                console.log('Context menu triggered at:', e.clientX, e.clientY);
-                
-                contextPosition = { x: e.clientX, y: e.clientY };
-                
-                // Get canvas position relative to the container
-                const containerRect = container.getBoundingClientRect();
-                const canvasPosition = { 
-                    x: e.clientX - containerRect.left, 
-                    y: e.clientY - containerRect.top 
-                };
-                console.log('Canvas position:', canvasPosition);
-                
-                // Use vis-network API to get the clicked position
-                const domPointer = { x: e.offsetX, y: e.offsetY };
-                // Convert DOM coordinates to canvas coordinates for node placement
-                const networkPointer = network.DOMtoCanvas(domPointer);
-                console.log('DOM pointer:', domPointer, 'Network pointer:', networkPointer);
-                
-                // Check what was clicked using vis-network methods
-                const nodeId = network.getNodeAt(domPointer);
-                const edgeId = network.getEdgeAt(domPointer);
-                console.log('Clicked on:', { nodeId, edgeId, domPointer, networkPointer });
-                
-                if (nodeId) {
-                    showNodeContextMenu(e.clientX, e.clientY, nodeId);
-                } else if (edgeId) {
-                    showEdgeContextMenu(e.clientX, e.clientY, edgeId);
-                } else {
-                    // Use simple coordinates instead of problematic network conversion
-                    const simpleCoords = { x: 0, y: 0 }; // Place at center
-                    showCanvasContextMenu(e.clientX, e.clientY, simpleCoords);
-                }
             });
             
-            // Also try adding the event listener to the canvas element directly
+            // Use vis-network's oncontext event exclusively for better reliability
             network.on('oncontext', (params) => {
                 console.log('vis-network oncontext event:', params);
                 if (params.event && params.event.preventDefault) {
@@ -837,11 +806,16 @@
                     const canvasPosition = { x: params.pointer.canvas.x, y: params.pointer.canvas.y };
                     const domPosition = { x: params.pointer.DOM.x, y: params.pointer.DOM.y };
                     
+                    console.log('Context menu triggered at DOM:', domPosition, 'Canvas:', canvasPosition);
+                    
                     if (params.nodes && params.nodes.length > 0) {
+                        console.log('Right-clicked on node:', params.nodes[0]);
                         showNodeContextMenu(domPosition.x, domPosition.y, params.nodes[0]);
                     } else if (params.edges && params.edges.length > 0) {
+                        console.log('Right-clicked on edge:', params.edges[0]);
                         showEdgeContextMenu(domPosition.x, domPosition.y, params.edges[0]);
                     } else {
+                        console.log('Right-clicked on canvas, showing add node menu');
                         showCanvasContextMenu(domPosition.x, domPosition.y, canvasPosition);
                     }
                 }


### PR DESCRIPTION
## Summary
**Critical Fix**: This addresses the missing piece from Issue #33 that wasn't included in the merged PR #35.

## Problem
PR #35 fixed the DataSet update issue but **missed the core event handler conflict** that still prevents context menus from working after New Graph or Load Graph operations.

**Current State After PR #35:**
- ✅ DataSets update correctly (no more new DataSet creation)
- ❌ Context menu still detects right-clicks but **doesn't show Add Node dialog**
- ❌ Console shows "Context menu triggered" but stops there

## Root Cause - Dual Event Handler Conflict
The issue is **conflicting event listeners**:
```javascript
// PROBLEMATIC - Two handlers for same event
container.addEventListener('contextmenu', (e) => {
    // Complex detection logic that sometimes fails after data updates
});
network.on('oncontext', (params) => {
    // Duplicate/conflicting logic
});
```

## Solution - Single Reliable Handler
```javascript
// FIXED - Single, reliable event handler
container.addEventListener('contextmenu', (e) => {
    e.preventDefault(); // Just disable browser menu
});
network.on('oncontext', (params) => {
    // All context menu logic here - consistent and reliable
});
```

## Technical Changes
- **Remove complex DOM contextmenu handler** that was causing interference
- **Use only vis-network's oncontext event** for all context menu functionality
- **Add detailed logging** for better debugging
- **Eliminate dual listener conflicts** that occur after data updates

## Why This Was Missed
1. **PR #35 was merged** with the DataSet fix (which helped but wasn't complete)
2. **Additional commits to the same branch** happened after merge
3. **The critical event handler fix never made it to main**

## Testing Evidence
From console logs, we can see the exact problem:
- `vis-network oncontext event` fires correctly ✅
- DOM `contextmenu` detects clicks but stops before calling `showCanvasContextMenu` ❌

## Impact
This completes the fix for Issue #33 - now Add Node works reliably after:
- New Graph operations
- Load Graph operations  
- Any graph data updates

Addresses the missing context menu functionality from #33

🤖 Generated with [Claude Code](https://claude.ai/code)